### PR TITLE
[UI] Remove unwanted linebreak

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1617,7 +1617,7 @@ void static Discover(boost::thread_group& threadGroup)
 
 void StartNode(boost::thread_group& threadGroup)
 {
-    uiInterface.InitMessage(_("Loading addresses...\n"));
+    uiInterface.InitMessage(_("Loading addresses..."));
     // Load addresses for peers.dat
     int64_t nStart = GetTimeMillis();
     {


### PR DESCRIPTION
Caused the InitMessage on the Splashscreen to "jiggle" when flicking 
between Address Loading and other loads.