### PR TITLE
[QT & RPC] QT Updates tab and Standardized DVM RPC

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>OptionsDialog</class>
  <widget class="QDialog" name="OptionsDialog">
@@ -600,6 +600,43 @@
           <widget class="QLineEdit" name="thirdPartyTxUrls">
            <property name="toolTip">
             <string>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+	 <widget class="QWidget" name="tabUpdates">
+      <attribute name="title">
+       <string>&amp;Updates</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_Updates">
+		<item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5_Updates">
+         <item>
+          <widget class="QCheckBox" name="notifyUpdates">
+           <property name="toolTip">
+            <string>Notify when an update is detected by the Decentralized Version Manager (DVM)</string>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LeftToRight</enum>
+           </property>
+           <property name="text">
+			   <string>Notify when updates are available</string>
            </property>
           </widget>
          </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -126,7 +126,8 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet) : QDialog(paren
 #endif
 
     ui->unit->setModel(new BitcoinUnits(this));
-
+	
+	
     /* Widget-to-option mapper */
     mapper = new QDataWidgetMapper(this);
     mapper->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
@@ -215,6 +216,9 @@ void OptionsDialog::setMapper()
 
     /* Masternode Tab */
     mapper->addMapping(ui->showMasternodesTab, OptionsModel::ShowMasternodesTab);
+	
+	/* Updates */
+	mapper->addMapping(ui->notifyUpdates, OptionsModel::EnableUpdates);
 }
 
 void OptionsDialog::enableOkButton()

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -172,6 +172,12 @@ void OptionsModel::Init()
         SoftSetArg("-anonymizezenzoamount", settings.value("nAnonymizeZenzoAmount").toString().toStdString());
 
     language = settings.value("language").toString();
+	
+	// Updates - Decentralized Version Manager (DVM)
+	if (!settings.contains("fEnableUpdates")) {
+		fUpdateCheck = true;
+		settings.setValue("fEnableUpdates", true);
+	} else fUpdateCheck = settings.value("fEnableUpdates").toBool();
 }
 
 void OptionsModel::Reset()
@@ -180,7 +186,7 @@ void OptionsModel::Reset()
 
     // Remove all entries from our QSettings object
     settings.clear();
-    resetSettings = true; // Needed in zenzo.cpp during shotdown to also remove the window positions
+    resetSettings = true; // Needed in zenzo.cpp during shutdown to also remove the window positions
 
     // default setting for OptionsModel::StartAtStartup - disabled
     if (GUIUtil::GetStartOnSystemStartup())
@@ -264,6 +270,8 @@ QVariant OptionsModel::data(const QModelIndex& index, int role) const
             return QVariant(nPreferredDenom);
         case AnonymizeZenzoAmount:
             return QVariant(nAnonymizeZenzoAmount);
+		case EnableUpdates:
+				return settings.value("fEnableUpdates");
         case Listen:
             return settings.value("fListen");
         default:
@@ -402,6 +410,12 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
             settings.setValue("nAnonymizeZenzoAmount", nAnonymizeZenzoAmount);
             emit anonymizeZenzoAmountChanged(nAnonymizeZenzoAmount);
             break;
+		case EnableUpdates:
+            if (settings.value("fEnableUpdates") != value) {
+				fUpdateCheck = value.toBool();
+                settings.setValue("fEnableUpdates", fUpdateCheck);
+            }
+            break;
         case CoinControlFeatures:
             fCoinControlFeatures = value.toBool();
             settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
@@ -462,6 +476,12 @@ void OptionsModel::setStakeSplitThreshold(int value)
                 walletdb.WriteStakeSplitThreshold(nStakeSplitThreshold);
         }
     }
+}
+
+/* Updates the DVM's status */
+void OptionsModel::setUpdateEnabled(bool value)
+{
+	fUpdateCheck = value;
 }
 
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -50,6 +50,7 @@ public:
         HideOrphans,    // bool
         AnonymizeZenzoAmount, //int
         ShowMasternodesTab,  // bool
+        EnableUpdates,  // bool
         Listen,              // bool
         StakeSplitThreshold, // int
         OptionIDRowCount,
@@ -65,6 +66,8 @@ public:
     void setDisplayUnit(const QVariant& value);
     /* Update StakeSplitThreshold's value in wallet */
     void setStakeSplitThreshold(int value);
+	/* DVM activation value */
+	void setUpdateEnabled(bool value);
 
     /* Explicit getters */
     bool getMinimizeToTray() { return fMinimizeToTray; }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -46,6 +46,7 @@ Value getdvmstatus(const Array& params, bool fHelp)
             "\nReturns the status of the DVM, it's peers, detected versions and update consensus progress as a json object.\n"
             "\nbResult:\n"
             "  {\n"
+            "    \"active\": true|false,          (bool) Is the Updater (DVM) active\n"
             "    \"status\": n,                   (numeric) The Consensus Status of the DVM (0 = No Upgrade Consensus, 1 = Upgrade Consensus Met)\n"
             "    \"total\": n,                    (numeric) The quantity of all measured peers\n"
             "    \"higher\": n,                   (numeric) The quantity of measured peers with a higher version than us\n"
@@ -56,6 +57,7 @@ Value getdvmstatus(const Array& params, bool fHelp)
             HelpExampleCli("getdvmstatus", "") + HelpExampleRpc("getdvmstatus", ""));
 
     Object obj;
+    obj.push_back(Pair("active", fUpdateCheck));
     obj.push_back(Pair("status", shouldUpgrade));
     obj.push_back(Pair("total", (lowerVerPeers + currentVerPeers + higherVerPeers)));
     obj.push_back(Pair("higher", higherVerPeers));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -38,27 +38,27 @@ Value getconnectioncount(const Array& params, bool fHelp)
     return (int)vNodes.size();
 }
 
-Value getdvmstatus(const Array& params, bool fHelp)
+Value getdvminfo(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getdvmstatus\n"
-            "\nReturns the status of the DVM, it's peers, detected versions and update consensus progress as a json object.\n"
+            "getdvminfo\n"
+            "\nReturns the internal data of the DVM as a json object.\n"
             "\nbResult:\n"
             "  {\n"
             "    \"active\": true|false,          (bool) Is the Updater (DVM) active\n"
-            "    \"status\": n,                   (numeric) The Consensus Status of the DVM (0 = No Upgrade Consensus, 1 = Upgrade Consensus Met)\n"
+            "    \"status\": true|false,          (bool) The Update Status of the DVM, true means an update is available\n"
             "    \"total\": n,                    (numeric) The quantity of all measured peers\n"
             "    \"higher\": n,                   (numeric) The quantity of measured peers with a higher version than us\n"
             "    \"current\": n,                  (numeric) The quantity of measured peers with a version matching us\n"
             "    \"lower\": n,                    (numeric) The quantity of measured peers with a lower version than us\n"
             "  }\n"
             "\nExamples:\n" +
-            HelpExampleCli("getdvmstatus", "") + HelpExampleRpc("getdvmstatus", ""));
+            HelpExampleCli("getdvminfo", "") + HelpExampleRpc("getdvminfo", ""));
 
     Object obj;
     obj.push_back(Pair("active", fUpdateCheck));
-    obj.push_back(Pair("status", shouldUpgrade));
+    obj.push_back(Pair("status", ((shouldUpgrade == 0) ? false : true)));
     obj.push_back(Pair("total", (lowerVerPeers + currentVerPeers + higherVerPeers)));
     obj.push_back(Pair("higher", higherVerPeers));
     obj.push_back(Pair("current", currentVerPeers));

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -238,10 +238,10 @@ Value stop(const Array& params, bool fHelp)
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "stop\n"
-            "\nStop Zenzo server.");
+            "\nStop the ZENZO server.");
     // Shutdown will take long enough that the response should get back
     StartShutdown();
-    return "Zenzo server stopping";
+    return "ZENZO server stopping";
 }
 
 
@@ -262,7 +262,7 @@ static const CRPCCommand vRPCCommands[] =
         {"network", "addnode", &addnode, true, true, false},
         {"network", "getaddednodeinfo", &getaddednodeinfo, true, true, false},
         {"network", "getconnectioncount", &getconnectioncount, true, false, false},
-        {"network", "getdvmstatus", &getdvmstatus, true, false, false},
+        {"network", "getdvminfo", &getdvminfo, true, false, false},
         {"network", "getnettotals", &getnettotals, true, true, false},
         {"network", "getpeerinfo", &getpeerinfo, true, false, false},
         {"network", "ping", &ping, true, false, false},

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -151,7 +151,7 @@ extern std::string HelpExampleRpc(std::string methodname, std::string args);
 extern void EnsureWalletIsUnlocked();
 
 extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, bool fHelp); // in rpcnet.cpp
-extern json_spirit::Value getdvmstatus(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getdvminfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value ping(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
The classic "getdvmstatus" has been replaced with "getdvminfo", as a change to standardize back with Bitcoin Core's informational RPCs. This will make things a bit more flush for developers and pro-users that are used to the Bitcoin codebase.
The QT GUI has also had further DVM integrations, in the Settings page, there is now an "Updates" tab, in which you can toggle the automatic update tracking. This can be used to silence update notifications, if you (for whatever reason) do not want to upgrade, or used to repell a false positive and / or targetted DVM network abuse.
By default, the DVM's update tracker functions as an "opt-out" service, staying on and active by default, but will follow and persist the user's settings when changed via the GUI. The RPC cannot yet control DVM settings.